### PR TITLE
Add unit and API tests; update requirements and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ presets.json
 mixerbee.db
 *.migrated
 #I have my reasons
-tests/*
 
 # Python
 __pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,7 @@ fastapi>=0.111,<1
 uvicorn[standard]>=0.29,<1
 
 google-generativeai
+
+# testing
+pytest>=8.0,<9
+httpx>=0.27,<1

--- a/tests/api/test_scheduler_router.py
+++ b/tests/api/test_scheduler_router.py
@@ -1,0 +1,82 @@
+import pytest
+from fastapi import HTTPException
+
+import app_state
+import models
+from routers import scheduler as scheduler_router
+
+
+def _daily_request(time_value="07:45"):
+    return models.ScheduleRequest(
+        job_type="builder",
+        playlist_name="Daily Mix",
+        user_id="u1",
+        schedule_details=models.ScheduleDetails(frequency="daily", time=time_value),
+        blocks=[{"type": "movie"}],
+    )
+
+
+def _weekly_request(days=None, time_value="19:00"):
+    return models.ScheduleRequest(
+        job_type="builder",
+        playlist_name="Weekly Mix",
+        user_id="u1",
+        schedule_details=models.ScheduleDetails(
+            frequency="weekly", time=time_value, days_of_week=days
+        ),
+        blocks=[{"type": "movie"}],
+    )
+
+
+def test_create_schedule_weekly_requires_days(monkeypatch):
+    monkeypatch.setattr(app_state, "is_configured", True)
+
+    with pytest.raises(HTTPException) as exc:
+        scheduler_router.api_create_schedule(_weekly_request(days=None))
+
+    assert exc.value.status_code == 400
+    assert "days_of_week" in exc.value.detail
+
+
+def test_create_schedule_daily_builds_crontab_and_calls_scheduler(monkeypatch):
+    monkeypatch.setattr(app_state, "is_configured", True)
+    captured = {}
+
+    def fake_add_schedule(schedule_data):
+        captured.update(schedule_data)
+        return "sched-123"
+
+    monkeypatch.setattr(
+        scheduler_router.scheduler.scheduler_manager, "add_schedule", fake_add_schedule
+    )
+
+    res = scheduler_router.api_create_schedule(_daily_request("07:45"))
+
+    assert res["status"] == "ok"
+    assert res["id"] == "sched-123"
+    assert captured["crontab"] == "45 07 * * *"
+
+
+def test_update_schedule_invalid_time_returns_400(monkeypatch):
+    monkeypatch.setattr(app_state, "is_configured", True)
+
+    with pytest.raises(HTTPException) as exc:
+        scheduler_router.api_update_schedule("s1", _daily_request("25:99"))
+
+    assert exc.value.status_code == 400
+    assert "Invalid schedule format" in exc.value.detail
+
+
+def test_update_schedule_returns_404_when_manager_fails(monkeypatch):
+    monkeypatch.setattr(app_state, "is_configured", True)
+    monkeypatch.setattr(
+        scheduler_router.scheduler.scheduler_manager,
+        "update_schedule",
+        lambda *_args, **_kwargs: False,
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        scheduler_router.api_update_schedule("s1", _daily_request("10:15"))
+
+    assert exc.value.status_code == 404
+    assert "not found" in exc.value.detail.lower()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/unit/test_builder.py
+++ b/tests/unit/test_builder.py
@@ -1,0 +1,131 @@
+from unittest.mock import patch
+
+import app.builder as builder
+
+
+def _episode(item_id: str):
+    return {"Id": item_id, "Type": "Episode", "Name": item_id}
+
+
+def test_generate_items_tv_interleaves_multiple_shows():
+    blocks = [{
+        "type": "tv",
+        "shows": [
+            {"name": "Show A", "season": 1, "episode": 1},
+            {"name": "Show B", "season": 1, "episode": 1},
+        ],
+        "mode": "count",
+        "count": 2,
+        "interleave": True,
+    }]
+    logs = []
+
+    def fake_series_id(name, _hdr):
+        return {"Show A": "sid-a", "Show B": "sid-b"}[name]
+
+    def fake_episodes(sid, *_args, **_kwargs):
+        return {
+            "sid-a": [_episode("A1"), _episode("A2")],
+            "sid-b": [_episode("B1"), _episode("B2")],
+        }[sid]
+
+    with patch("app.builder.series_id", side_effect=fake_series_id), patch(
+        "app.builder.episodes", side_effect=fake_episodes
+    ):
+        items = builder.generate_items_from_blocks("u1", blocks, {}, logs)
+
+    assert [i["Id"] for i in items] == ["A1", "B1", "A2", "B2"]
+    assert any("interleaved episodes" in line for line in logs)
+
+
+def test_generate_items_tv_sequential_when_interleave_disabled():
+    blocks = [{
+        "type": "tv",
+        "shows": [
+            {"name": "Show A", "season": 1, "episode": 1},
+            {"name": "Show B", "season": 1, "episode": 1},
+        ],
+        "mode": "count",
+        "count": 2,
+        "interleave": False,
+    }]
+    logs = []
+
+    def fake_series_id(name, _hdr):
+        return {"Show A": "sid-a", "Show B": "sid-b"}[name]
+
+    def fake_episodes(sid, *_args, **_kwargs):
+        return {
+            "sid-a": [_episode("A1"), _episode("A2")],
+            "sid-b": [_episode("B1"), _episode("B2")],
+        }[sid]
+
+    with patch("app.builder.series_id", side_effect=fake_series_id), patch(
+        "app.builder.episodes", side_effect=fake_episodes
+    ):
+        items = builder.generate_items_from_blocks("u1", blocks, {}, logs)
+
+    assert [i["Id"] for i in items] == ["A1", "A2", "B1", "B2"]
+    assert any("sequential episodes" in line for line in logs)
+
+
+def test_generate_items_logs_unprocessed_show_entry_and_skips_it():
+    blocks = [{"type": "tv", "shows": [{"season": 1, "episode": 1}], "count": 1}]
+    logs = []
+
+    items = builder.generate_items_from_blocks("u1", blocks, {}, logs)
+
+    assert items == []
+    assert any("Could not process show entry" in line for line in logs)
+
+
+def test_generate_items_movie_block_adds_movies_and_logs_count():
+    blocks = [{"type": "movie", "filters": {"genres_any": ["Action"]}}]
+    logs = []
+    fake_movies = [{"Id": "m1", "Type": "Movie"}, {"Id": "m2", "Type": "Movie"}]
+
+    with patch("app.builder.find_movies", return_value=fake_movies) as mock_find:
+        items = builder.generate_items_from_blocks("u1", blocks, {}, logs)
+
+    assert items == fake_movies
+    mock_find.assert_called_once()
+    assert any("Added 2 movies" in line for line in logs)
+
+
+def test_generate_items_music_album_mode_uses_album_lookup():
+    blocks = [{"type": "music", "music": {"mode": "album", "albumId": "alb-1"}}]
+    logs = []
+    fake_songs = [{"Id": "s1", "Type": "Audio"}]
+
+    with patch("app.builder.get_songs_by_album", return_value=fake_songs) as mock_album:
+        items = builder.generate_items_from_blocks("u1", blocks, {}, logs)
+
+    assert items == fake_songs
+    mock_album.assert_called_once_with("alb-1", {})
+    assert any("Added 1 songs" in line for line in logs)
+
+
+def test_create_mixed_playlist_returns_error_when_no_items_found():
+    with patch("app.builder.generate_items_from_blocks", return_value=[]):
+        result = builder.create_mixed_playlist("u1", "Mix", [{"type": "movie"}], {})
+
+    assert result["status"] == "error"
+    assert "No items were found" in " ".join(result["log"])
+
+
+def test_create_mixed_playlist_success_calls_create_playlist_with_item_ids():
+    built_items = [{"Id": "e1"}, {"Id": "m2"}]
+    with patch("app.builder.generate_items_from_blocks", return_value=built_items), patch(
+        "app.builder.create_playlist", return_value="new-playlist-id"
+    ) as mock_create:
+        result = builder.create_mixed_playlist("u1", "Mix", [{"type": "movie"}], {"H": "V"})
+
+    assert result["status"] == "ok"
+    assert result["new_item_id"] == "new-playlist-id"
+    mock_create.assert_called_once_with(
+        name="Mix",
+        user_id="u1",
+        ids=["e1", "m2"],
+        hdr={"H": "V"},
+        log=result["log"],
+    )


### PR DESCRIPTION
### Motivation
- Make test suite part of the repository and ensure CI/dev environments can run unit and API tests.
- Add coverage for the playlist builder logic and scheduler router input/validation behavior.
- Ensure test dependencies are declared so test runs are reproducible.

### Description
- Remove `tests/*` from `.gitignore` so test files are tracked in the repository.
- Add testing dependencies to `requirements.txt` by including `pytest>=8.0,<9` and `httpx>=0.27,<1`.
- Add `tests/conftest.py` to insert the repo root on `sys.path` for test imports.
- Add `tests/unit/test_builder.py` with unit tests for `app.builder` and `tests/api/test_scheduler_router.py` with API-level tests for the scheduler router.

### Testing
- Ran `pytest -q` to execute the new unit and API tests.
- All tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a13d7d08e8832481b1153da633af85)