### PR TITLE
Feature: Real-Time Playlist Updates via Webhooks & In-Place ID Preservation

### DIFF
--- a/routers/webhooks.py
+++ b/routers/webhooks.py
@@ -1,0 +1,84 @@
+"""
+routers/webhooks.py – APIRouter for handling live events from Emby/Jellyfin
+"""
+
+import logging
+from fastapi import APIRouter, BackgroundTasks, Request
+from typing import Dict, Any
+
+import app_state
+from scheduler import scheduler_manager
+
+router = APIRouter()
+
+def trigger_relevant_schedules(user_id: str = None):
+    """
+    Background worker that iterates through existing schedules and runs them.
+    If a user_id is provided by the webhook, it only updates that user's playlists.
+    """
+    if not app_state.is_configured:
+        return
+
+    schedules = scheduler_manager.get_all_schedules()
+    triggered_count = 0
+
+    for sched in schedules:
+        # If the webhook gave us a specific user, only update their stuff to save resources.
+        if user_id is None or sched.get("user_id") == user_id:
+            try:
+                logging.info(f"WEBHOOK: Triggering live update for schedule '{sched.get('playlist_name')}'")
+                scheduler_manager.run_schedule_now(sched["id"])
+                triggered_count += 1
+            except Exception as e:
+                logging.error(f"WEBHOOK: Failed to run schedule {sched['id']} during live update: {e}")
+
+    logging.info(f"WEBHOOK: Finished live update. {triggered_count} schedule(s) refreshed.")
+
+
+@router.post("/api/webhook")
+async def handle_media_webhook(request: Request, background_tasks: BackgroundTasks):
+    """
+    Receives JSON payloads from the Emby/Jellyfin Webhook plugin.
+    Returns 200 immediately and processes the updates in the background.
+    """
+    if not app_state.is_configured:
+        return {"status": "ignored", "reason": "App not configured"}
+
+    try:
+        payload: Dict[str, Any] = await request.json()
+    except Exception:
+        payload = {}
+
+    # Emby Webhook Plugin usually sends the event type in "Event"
+    event_type = payload.get("Event", "")
+    event_type_lower = event_type.lower()
+    
+    # Extract User ID if it's a user-specific event (like PlaybackStop)
+    user_id = None
+    if "User" in payload and isinstance(payload["User"], dict):
+        user_id = payload["User"].get("Id")
+    elif "UserId" in payload:
+        user_id = payload.get("UserId")
+
+    # We use lowercase keywords to safely catch both Emby and Jellyfin event names
+    # e.g. "stop" catches "playback.stop" (Emby) and "PlaybackStop" (Jellyfin)
+    relevant_keywords = [
+        "stop",       # Playback Stop
+        "played",     # Mark Played / Mark Unplayed
+        "userdata",   # User Data Changed (Jellyfin equivalent)
+        "new",        # New Media Added (Emby: library.new)
+        "added",      # New Media Added (Jellyfin: ItemAdded)
+        "removed",    # Media Removed (Jellyfin: ItemRemoved)
+        "deleted"     # Media Removed (Emby: library.deleted)
+    ]
+
+    # If the payload matches a keyword, or is empty (a test ping), we process it
+    if not event_type_lower or any(keyword in event_type_lower for keyword in relevant_keywords):
+        logging.info(f"WEBHOOK: Received relevant event '{event_type}'. Queuing background refresh.")
+        
+        # Add the rebuild process to FastAPI's background queue
+        background_tasks.add_task(trigger_relevant_schedules, user_id)
+        
+        return {"status": "accepted", "message": "Playlist rebuild queued."}
+
+    return {"status": "ignored", "reason": f"Event '{event_type}' does not require playlist updates."}

--- a/web.py
+++ b/web.py
@@ -15,6 +15,7 @@ import database
 from app.cache import refresh_cache 
 from routers import config, builder, library, quick_playlists, presets
 from routers import scheduler as scheduler_router
+from routers import webhooks
 
 IS_DOCKER = os.path.exists('/.dockerenv')
 ROOT_PATH = "" if IS_DOCKER else "/mixerbee"
@@ -30,6 +31,7 @@ app.include_router(library.router)
 app.include_router(quick_playlists.router)
 app.include_router(scheduler_router.router)
 app.include_router(presets.router)
+app.include_router(webhooks.router)
 
 @app.on_event("startup")
 def startup_event():


### PR DESCRIPTION
**Technical Changes:**
* **In-Place Playlist Updates:** Refactored `app/items.py` to update existing playlists by matching their names and swapping the `PlaylistItemId`s inside them. This prevents the deleting and recreating playlists, which previously destroyed the Emby/Jellyfin UID and broke pinned UI shortcuts.
* **New Webhook Listener:** Added a new FastAPI router (`/api/webhook`) that listens for incoming JSON payloads from the media server.
* **Universal Keyword Matching:** Implemented a robust keyword-matching system (e.g., `"stop"`, `"played"`, `"added"`) to automatically handle the different event naming conventions between Emby and Jellyfin without needing separate endpoints.
* **Non-Blocking Background Tasks:** Wrapped the playlist rebuild logic in FastAPI's `BackgroundTasks`. MixerBee returns a `200 OK` to the media server to prevent hanging, then processes the heavy database filtering in the background.
* **User-Aware Triggering:** The webhook logic extracts the triggering User ID from the payload and ensures MixerBee *only* rebuilds schedules owned by that specific user, saving CPU cycles and preventing multi-user crossover.

---

### How to Enable Real-Time "Live" Playlist Updates

MixerBee can listen to your Emby or Jellyfin server in real-time. Instead of waiting for a scheduled daily task, MixerBee can instantly rebuild your scheduled playlists (like "Next Up" or custom blocks) the second you finish watching an episode or add new media to your library.

**Prerequisites:** * Ensure the official **Webhooks** plugin is installed on your Emby/Jellyfin server *(Emby requires an active Premiere subscription for Webhooks)*.

**Configuration Steps:**
1. **Navigate to Notifications:** In Emby, click your **User Profile Icon** (**Settings** -> **Notifications**.
2. **Add a Webhook:** Click **`+ Add Notification`** and select **Webhooks** from the list.
3. **Set the URL:** Enter your MixerBee address ending in `/api/webhook` (e.g., `http://192.168.1.50:8000/api/webhook`).
4. **Content Type:** Ensure the payload format is set to **`application/json`**.
5. **Select Events:** Check the boxes for the events you want MixerBee to react to. We recommend:
   * **Playback:** `Stop`
   * **Users:** `Mark Played`, `Mark Unplayed`
   * **Library:** `New Media Added`, `Media Removed`
6. **Set the User Filter:** **(Important!)** Make sure you select your specific username in the User Filter checklist. This ensures MixerBee only rebuilds *your* playlists when *you* watch something, ignoring other users on the server.
7. **Save and Test:** Click save. Any playlist you have active in the MixerBee **Scheduler** tab will now automatically update in the background when these events occur.