### PR TITLE
Bugfix: API NoneType Sorting Crash

### DIFF
--- a/app/tv.py
+++ b/app/tv.py
@@ -65,8 +65,8 @@ def episodes(sid: str, season: int, episode: int, count: int,
                            params=params, headers=hdr, timeout=10)
     r.raise_for_status()
     all_eps = sorted(r.json()["Items"],
-                   key=lambda x: (x.get("ParentIndexNumber", 0),
-                                  x.get("IndexNumber", 0)))
+                   key=lambda x: (x.get("ParentIndexNumber") or 0,
+                                  x.get("IndexNumber") or 0))
 
     # Filter out specials (season 0)
     all_eps = [ep for ep in all_eps if ep.get("ParentIndexNumber", 0) > 0]
@@ -123,8 +123,8 @@ def get_first_unwatched_episode(series_id: str, user_id: str,
                            params=params, headers=hdr, timeout=15)
     r.raise_for_status()
     all_eps = sorted(r.json().get("Items", []),
-                     key=lambda x: (x.get("ParentIndexNumber", 0),
-                                    x.get("IndexNumber", 0)))
+                     key=lambda x: (x.get("ParentIndexNumber") or 0,
+                                    x.get("IndexNumber") or 0))
     regular_eps = [ep for ep in all_eps if ep.get("ParentIndexNumber", 0) > 0]
     for ep in regular_eps:
         user_data = ep.get("UserData", {})


### PR DESCRIPTION
Emby and Jellyfin APIs return null (i.e. Python None) for ParentIndexNumber or IndexNumber if metadata is missing.
Current sorting logic uses .get("IndexNumber", 0). If the key exists but is None, .get() returns None (not 0)could throw a fatal TypeError: '<' not supported between instances of 'NoneType' and 'int'.