### PR TITLE
feat: New Echo block (Taste Mirror) for similarity mixing

### DIFF
--- a/app/ai/orchestrator.py
+++ b/app/ai/orchestrator.py
@@ -146,7 +146,6 @@ def _map_tv_block(ai_block: AIBlock) -> Optional[Dict[str, Any]]:
     elif ai_block.tv_shows:
         shows = [{"name": n, "season": 1, "episode": 1, "unwatched": is_unwatched} for n in ai_block.tv_shows if n and str(n).strip()]
 
-    # If the LLM generated an empty block, drop it entirely instead of returning a blank row
     if not shows:
         return None
 
@@ -166,7 +165,7 @@ def _map_movie_block(ai_block: AIBlock) -> Optional[Dict[str, Any]]:
 
     filters: Dict[str, Any] = {
         "watched_status": "unplayed" if is_unwatched else "all",
-        "sort_by": "PremiereDate", # Switched from Random to PremiereDate to keep AI ID ordering stable on preview
+        "sort_by": "PremiereDate",
     }
 
     if ai_block.movie_ids:
@@ -293,8 +292,6 @@ def _run_ollama_researcher(prompt: str, tweaks: AiTweaks) -> tuple[List[Dict[str
             args = call["function"].get("arguments", {})
             if func_name in tool_map:
                 try:
-                    # LLMs often hallucinate a 'limit' or 'count' param if the user asked for a specific number.
-                    # Delete it so we always get a deep pool of candidates from the Vector DB for the Architect to filter!
                     args.pop("limit", None)
                     args.pop("count", None)
 

--- a/app/ai/vector_store.py
+++ b/app/ai/vector_store.py
@@ -1,5 +1,5 @@
 """
-app/ai/vector_store.py - Vector DB init and config.
+app/ai/vector_store.py - Vector DB init and config with robust similarity search.
 """
 
 import json
@@ -7,6 +7,7 @@ import time
 import threading
 from typing import List, Dict, Optional
 import chromadb
+import numpy as np
 
 import app.client as client
 from app_state import CONFIG_DIR
@@ -311,12 +312,6 @@ def search_by_vibe(query: str = None, media_type: str = None, limit: int = None,
     """
     Searches the library for media matching a specific vibe, mood, theme, or description.
     Includes a 'Radius Lock' to filter out mathematically irrelevant results.
-
-    Args:
-        query: The conceptual vibe or theme to search for (e.g., "gritty cyberpunk", "90s sitcom").
-        media_type: Optional. Filter strictly by format: use 'Movie' or 'Series'.
-        limit: Optional override for search depth.
-        threshold: Optional override for relevancy strictness (0.0 to 1.0).
     """
     refresh_logger_level()
     if not query:
@@ -371,7 +366,7 @@ def search_by_vibe(query: str = None, media_type: str = None, limit: int = None,
             include=["metadatas", "distances"]
         )
 
-        if not results['ids'] or not results['ids'][0]:
+        if not results or not results.get('ids') or len(results['ids'][0]) == 0:
             return []
 
         matched_items = []
@@ -400,3 +395,81 @@ def search_by_vibe(query: str = None, media_type: str = None, limit: int = None,
     except Exception as e:
         logger.error(f"Vibe search failed: {e}")
         return []
+
+def search_by_composite_similarity(positive_ids: list, negative_ids: list, limit: int = 10, threshold: float = 0.65):
+    """
+    Finds items similar to a weighted average of multiple seed items, minus negative seeds.
+    """
+    refresh_logger_level()
+    all_ids = positive_ids + negative_ids
+    if not positive_ids:
+        return []
+
+    try:
+        res = media_collection.get(ids=all_ids, include=["embeddings", "metadatas"])
+        
+        if not res or res.get('embeddings') is None or len(res['embeddings']) == 0:
+            logger.warning("Composite Search: Could not find embeddings for requested seeds.")
+            return []
+
+        vectors = {res['ids'][i]: np.array(res['embeddings'][i]) for i in range(len(res['ids']))}
+        id_to_type = {res['ids'][i]: res['metadatas'][i].get("type") for i in range(len(res['ids']))}
+
+        pos_vectors = [vectors[pid] for pid in positive_ids if pid in vectors]
+        if not pos_vectors:
+            return []
+        
+        composite_vector = np.mean(pos_vectors, axis=0)
+
+        neg_vectors = [vectors[nid] for nid in negative_ids if nid in vectors]
+        for neg_vec in neg_vectors:
+            composite_vector = composite_vector - (neg_vec * 0.4)
+
+        target_type = id_to_type.get(positive_ids[0])
+
+        results = media_collection.query(
+            query_embeddings=[composite_vector.tolist()],
+            n_results=limit + len(all_ids) + 5,
+            where={"type": target_type} if target_type else None,
+            include=["metadatas", "distances"]
+        )
+
+        if not results or not results.get('ids') or len(results['ids'][0]) == 0:
+            return []
+
+        matched_items = []
+        seed_id_set = set(all_ids)
+
+        for i in range(len(results['ids'][0])):
+            cid = results['ids'][0][i]
+            if cid in seed_id_set:
+                continue
+
+            name = results['metadatas'][0][i]["name"]
+            distance = results['distances'][0][i] if results['distances'] else 0.0
+
+            if distance > threshold:
+                logger.info(f"   [COMP-SKIP] {name} | Distance: {distance:.4f} (Too far)")
+                continue
+
+            matched_items.append({
+                "Id": cid,
+                "Name": name,
+                "Type": results['metadatas'][0][i]["type"],
+                "Year": results['metadatas'][0][i].get("year", "Unknown"),
+                "Genres": results['metadatas'][0][i].get("genres", ""),
+                "Distance": distance
+            })
+            logger.info(f"   [COMP-MATCH] {name} | Distance: {distance:.4f}")
+
+        return matched_items[:limit]
+
+    except Exception as e:
+        logger.error(f"Composite similarity search failed: {e}", exc_info=True)
+        return []
+
+def search_by_similarity(item_id: str, limit: int = 10, threshold: float = 0.65) -> List[Dict[str, str]]:
+    """
+    Finds items mathematically similar to a specific seed item.
+    """
+    return search_by_composite_similarity(positive_ids=[item_id], negative_ids=[], limit=limit, threshold=threshold)

--- a/app/ai/vector_store.py
+++ b/app/ai/vector_store.py
@@ -377,7 +377,7 @@ def search_by_vibe(query: str = None, media_type: str = None, limit: int = None,
             distance = results['distances'][0][i] if results['distances'] else 0.0
 
             if distance > current_threshold:
-                logger.info(f"   [SKIPPED] {name} ({year}) | Cosine Distance: {distance:.4f} (Outside Radius)")
+                logger.info(f"    [SKIPPED] {name} ({year}) | Cosine Distance: {distance:.4f} (Outside Radius)")
                 continue
 
             matched_items.append({
@@ -389,14 +389,14 @@ def search_by_vibe(query: str = None, media_type: str = None, limit: int = None,
                 "Distance": distance
             })
 
-            logger.info(f"   [KEEP] {name} ({year}) [ID: {item_id}] | Cosine Distance: {distance:.4f}")
+            logger.info(f"    [KEEP] {name} ({year}) [ID: {item_id}] | Cosine Distance: {distance:.4f}")
 
         return matched_items
     except Exception as e:
         logger.error(f"Vibe search failed: {e}")
         return []
 
-def search_by_composite_similarity(positive_ids: list, negative_ids: list, limit: int = 10, threshold: float = 0.65):
+def search_by_composite_similarity(positive_ids: list, negative_ids: list, limit: int = 10, threshold: float = 0.65, mixed_echo: bool = False):
     """
     Finds items similar to a weighted average of multiple seed items, minus negative seeds.
     """
@@ -425,7 +425,7 @@ def search_by_composite_similarity(positive_ids: list, negative_ids: list, limit
         for neg_vec in neg_vectors:
             composite_vector = composite_vector - (neg_vec * 0.4)
 
-        target_type = id_to_type.get(positive_ids[0])
+        target_type = id_to_type.get(positive_ids[0]) if not mixed_echo else None
 
         results = media_collection.query(
             query_embeddings=[composite_vector.tolist()],
@@ -440,27 +440,38 @@ def search_by_composite_similarity(positive_ids: list, negative_ids: list, limit
         matched_items = []
         seed_id_set = set(all_ids)
 
-        for i in range(len(results['ids'][0])):
-            cid = results['ids'][0][i]
-            if cid in seed_id_set:
-                continue
+        def build_matches(current_threshold):
+            items = []
+            for i in range(len(results['ids'][0])):
+                cid = results['ids'][0][i]
+                if cid in seed_id_set:
+                    continue
 
-            name = results['metadatas'][0][i]["name"]
-            distance = results['distances'][0][i] if results['distances'] else 0.0
+                name = results['metadatas'][0][i]["name"]
+                distance = results['distances'][0][i] if results['distances'] else 0.0
 
-            if distance > threshold:
-                logger.info(f"   [COMP-SKIP] {name} | Distance: {distance:.4f} (Too far)")
-                continue
+                if distance > current_threshold:
+                    continue
 
-            matched_items.append({
-                "Id": cid,
-                "Name": name,
-                "Type": results['metadatas'][0][i]["type"],
-                "Year": results['metadatas'][0][i].get("year", "Unknown"),
-                "Genres": results['metadatas'][0][i].get("genres", ""),
-                "Distance": distance
-            })
-            logger.info(f"   [COMP-MATCH] {name} | Distance: {distance:.4f}")
+                items.append({
+                    "Id": cid,
+                    "Name": name,
+                    "Type": results['metadatas'][0][i]["type"],
+                    "Year": results['metadatas'][0][i].get("year", "Unknown"),
+                    "Genres": results['metadatas'][0][i].get("genres", ""),
+                    "Distance": distance
+                })
+            return items
+
+        matched_items = build_matches(threshold)
+
+        if not matched_items:
+            fallback_threshold = threshold + 0.10
+            logger.info(f"Composite Search: No items within threshold {threshold:.2f}. Retrying with fallback {fallback_threshold:.2f}...")
+            matched_items = build_matches(fallback_threshold)
+
+        for item in matched_items:
+            logger.info(f"   [COMP-MATCH] {item['Name']} | Distance: {item['Distance']:.4f}")
 
         return matched_items[:limit]
 

--- a/app/builder.py
+++ b/app/builder.py
@@ -114,8 +114,6 @@ def _process_movie_block(block: Dict[str, Any], user_id: str, hdr: Dict[str, str
 def _process_mirror_block(block: Dict[str, Any], user_id: str, hdr: Dict[str, str], log_messages: List[str], block_index: int) -> List[Dict[str, Any]]:
     """
     Handles logic for the Echo (Mirror) block.
-    Uses 'Deep Pool Sampling' to keep the results fresh and non-deterministic.
-    Now supports Composite Vector searches with positive and negative seeds.
     """
     items = []
     try:
@@ -124,6 +122,7 @@ def _process_mirror_block(block: Dict[str, Any], user_id: str, hdr: Dict[str, st
         filters = block.get("filters", {})
         seeds_pos = [s['Id'] for s in filters.get("seeds_positive", [])]
         seeds_neg = [s['Id'] for s in filters.get("seeds_negative", [])]
+        mixed_echo = filters.get("mixed_echo", False)
         
         target_limit = int(block.get("limit", 10))
         threshold = float(block.get("threshold", 0.65))
@@ -136,7 +135,8 @@ def _process_mirror_block(block: Dict[str, Any], user_id: str, hdr: Dict[str, st
             positive_ids=seeds_pos, 
             negative_ids=seeds_neg, 
             limit=pool_size, 
-            threshold=threshold
+            threshold=threshold,
+            mixed_echo=mixed_echo
         )
         
         if not similar_pool:

--- a/app/builder.py
+++ b/app/builder.py
@@ -1,5 +1,5 @@
 """
-app/builder.py - Logic for building mixed playlists from blocks
+app/builder.py - Logic for building mixed playlists from blocks with randomized Echo sampling.
 """
 
 import logging
@@ -36,7 +36,6 @@ def _process_tv_block(block: Dict[str, Any], user_id: str, hdr: Dict[str, str], 
                 if not sid:
                     continue
 
-                # Trust the UI's selected season/episode unconditionally to guarantee stability
                 s = raw_show.get("season")
                 e = raw_show.get("episode")
                 is_unwatched = raw_show.get("unwatched", False)
@@ -44,7 +43,6 @@ def _process_tv_block(block: Dict[str, Any], user_id: str, hdr: Dict[str, str], 
                 if s is not None: s = int(s)
                 if e is not None: e = int(e)
 
-                # ONLY run smart resolution if the payload is missing S/E data
                 if s is None or e is None:
                     if is_unwatched:
                         ep_info = get_first_unwatched_episode(sid, user_id, hdr)
@@ -60,7 +58,6 @@ def _process_tv_block(block: Dict[str, Any], user_id: str, hdr: Dict[str, str], 
                         else:
                             s, e = 1, 1
 
-                # Fetch episodes sequentially starting from strictly locked S/E
                 eps = episodes(sid, s, e, count, hdr, user_id=user_id, only_unwatched=is_unwatched)
 
                 if eps:
@@ -103,7 +100,6 @@ def _process_movie_block(block: Dict[str, Any], user_id: str, hdr: Dict[str, str
                 if limit_val is not None:
                     id_filters["limit"] = int(limit_val)
                     
-                # Preserve sort properties if UI provided them
                 if "sort_by" in filters:
                     id_filters["sort_by"] = filters["sort_by"]
 
@@ -115,6 +111,67 @@ def _process_movie_block(block: Dict[str, Any], user_id: str, hdr: Dict[str, str
         logging.error(f"Error processing Movie block {block_index}: {e}", exc_info=True)
     return items
 
+def _process_mirror_block(block: Dict[str, Any], user_id: str, hdr: Dict[str, str], log_messages: List[str], block_index: int) -> List[Dict[str, Any]]:
+    """
+    Handles logic for the Echo (Mirror) block.
+    Uses 'Deep Pool Sampling' to keep the results fresh and non-deterministic.
+    Now supports Composite Vector searches with positive and negative seeds.
+    """
+    items = []
+    try:
+        from .ai.vector_store import search_by_composite_similarity
+        
+        filters = block.get("filters", {})
+        seeds_pos = [s['Id'] for s in filters.get("seeds_positive", [])]
+        seeds_neg = [s['Id'] for s in filters.get("seeds_negative", [])]
+        
+        target_limit = int(block.get("limit", 10))
+        threshold = float(block.get("threshold", 0.65))
+
+        if not seeds_pos:
+            return []
+
+        pool_size = max(40, target_limit * 4)
+        similar_pool = search_by_composite_similarity(
+            positive_ids=seeds_pos, 
+            negative_ids=seeds_neg, 
+            limit=pool_size, 
+            threshold=threshold
+        )
+        
+        if not similar_pool:
+            return []
+
+        sampled_matches = random.sample(similar_pool, min(target_limit, len(similar_pool)))
+
+        movie_ids = []
+        series_ids = []
+
+        for match in sampled_matches:
+            m_type = match.get("Type")
+            m_id = match.get("Id")
+            if m_type == "Movie":
+                movie_ids.append(m_id)
+            elif m_type == "Series":
+                series_ids.append(m_id)
+
+        if movie_ids:
+            resolved_movies = find_movies(user_id=user_id, filters={"ids": movie_ids}, hdr=hdr)
+            items.extend(resolved_movies)
+
+        for sid in series_ids:
+            next_ep = get_first_unwatched_episode(sid, user_id, hdr)
+            if not next_ep:
+                next_ep = get_first_available_episode(sid, user_id, hdr)
+            
+            if next_ep:
+                items.append(next_ep)
+
+        random.shuffle(items)
+
+    except Exception as e:
+        logging.error(f"Error processing Echo block {block_index}: {e}", exc_info=True)
+    return items
 
 def _process_music_block(block: Dict[str, Any], user_id: str, hdr: Dict[str, str], log_messages: List[str], block_index: int) -> List[Dict[str, Any]]:
     items = []
@@ -159,6 +216,8 @@ def generate_items_from_blocks(user_id: str, blocks: List[Dict[str, Any]], hdr: 
             master_items_list.extend(_process_movie_block(block, user_id, hdr, log_messages, i))
         elif block_type == "music":
             master_items_list.extend(_process_music_block(block, user_id, hdr, log_messages, i))
+        elif block_type == "mirror" or block_type == "echo":
+            master_items_list.extend(_process_mirror_block(block, user_id, hdr, log_messages, i))
 
     return master_items_list
 

--- a/routers/library.py
+++ b/routers/library.py
@@ -109,16 +109,17 @@ def api_search_media(query: str, auth_deps: dict = Depends(get_current_auth_head
         res = media_collection.get(
             include=["metadatas"]
         )
-        if not res or not res['ids']:
-            return []
         
+        if not res or not res.get('ids'):
+            return []
+
         search_term = query.lower()
         results = []
-        
+
         for i, item_id in enumerate(res['ids']):
             meta = res['metadatas'][i]
             name = meta.get("name", "Unknown")
-            
+
             if search_term in name.lower():
                 results.append({
                     "Id": item_id,
@@ -126,10 +127,10 @@ def api_search_media(query: str, auth_deps: dict = Depends(get_current_auth_head
                     "Year": meta.get("year", ""),
                     "Type": meta.get("type", "")
                 })
-            
-            if len(results) >= 15:
-                break
-                
+
+                if len(results) >= 15:
+                    break
+
         return results
     except Exception as e:
         logging.error(f"Media search failed: {e}")

--- a/routers/library.py
+++ b/routers/library.py
@@ -12,7 +12,7 @@ import app as core
 import models
 import app_state
 from app.cache import get_library_data
-from app.ai.vector_store import calculate_library_iq
+from app.ai.vector_store import calculate_library_iq, media_collection
 from .dependencies import get_current_auth_headers
 
 router = APIRouter()
@@ -55,8 +55,6 @@ def api_episode_lookup(series_id: str, season: int, episode: int, auth_deps: dic
             "episode": episode
         }
     
-    # Smart fallback: if the UI asked for S1E1 (the default) and it doesn't exist,
-    # find the actual first available episode in the library (e.g., S9E1)
     if season == 1 and episode == 1:
         first_ep = core.get_first_available_episode(series_id, auth_deps["login_uid"], auth_deps["hdr"])
         if first_ep:
@@ -103,6 +101,39 @@ def api_get_studios(name: str = "", auth_deps: dict = Depends(get_current_auth_h
     """Searches for studios by name using the cached library data."""
     library_data = get_library_data()
     return core.get_studios(name, library_data)
+
+@router.get("/api/media/search")
+def api_search_media(query: str, auth_deps: dict = Depends(get_current_auth_headers)) -> List[Dict[str, Any]]:
+    """Global search for any media (movies/shows) in the vector store."""
+    try:
+        res = media_collection.get(
+            include=["metadatas"]
+        )
+        if not res or not res['ids']:
+            return []
+        
+        search_term = query.lower()
+        results = []
+        
+        for i, item_id in enumerate(res['ids']):
+            meta = res['metadatas'][i]
+            name = meta.get("name", "Unknown")
+            
+            if search_term in name.lower():
+                results.append({
+                    "Id": item_id,
+                    "Name": name,
+                    "Year": meta.get("year", ""),
+                    "Type": meta.get("type", "")
+                })
+            
+            if len(results) >= 15:
+                break
+                
+        return results
+    except Exception as e:
+        logging.error(f"Media search failed: {e}")
+        return []
 
 @router.get("/api/music/random_artist")
 def api_get_random_artist(auth_deps: dict = Depends(get_current_auth_headers)) -> Dict[str, str]:

--- a/static/js/mixerStore.js
+++ b/static/js/mixerStore.js
@@ -98,7 +98,7 @@ export const mixerStore = {
 
         if (block.type === 'mirror') {
             if (!block.filters) block.filters = {};
-            
+
             if (block.seedId && (!block.filters.seeds_positive || block.filters.seeds_positive.length === 0)) {
                 block.filters.seeds_positive = [{ Id: block.seedId, Name: block.seedName }];
                 delete block.seedId;
@@ -107,6 +107,7 @@ export const mixerStore = {
 
             block.filters.seeds_positive = block.filters.seeds_positive ?? [];
             block.filters.seeds_negative = block.filters.seeds_negative ?? [];
+            block.filters.mixed_echo = block.filters.mixed_echo ?? false;
             block.limit = block.limit ?? 10;
             block.threshold = block.threshold ?? 0.65;
         }
@@ -115,12 +116,12 @@ export const mixerStore = {
             if (!block.shows) block.shows = [];
             block.shows.forEach(s => {
                 if (!s._uid) s._uid = generateUUID();
-                
+
                 if (!s.name && s.id) {
                     const seriesMatch = this.library.seriesData.find(ls => String(ls.id) === String(s.id));
                     if (seriesMatch) s.name = seriesMatch.name;
                 }
-                
+
                 if (s.season === undefined) s.season = 1;
                 if (s.episode === undefined) s.episode = 1;
 
@@ -424,7 +425,7 @@ export const mixerStore = {
         } else if (type === 'music') {
             block = { type: 'music', music: { mode: 'album', count: 10, filters: { sort_by: 'Random', limit: 25, genres: [], genre_match: 'any' } } };
         } else if (type === 'mirror') {
-            block = { type: 'mirror', filters: { seeds_positive: [], seeds_negative: [] }, limit: 10, threshold: 0.65 };
+            block = { type: 'mirror', filters: { seeds_positive: [], seeds_negative: [], mixed_echo: false }, limit: 10, threshold: 0.65 };
         }
 
         if (block) {

--- a/static/js/mixerStore.js
+++ b/static/js/mixerStore.js
@@ -96,6 +96,21 @@ export const mixerStore = {
             if (!block.music.filters) block.music.filters = { sort_by: 'Random', limit: 25, genres: [], genre_match: 'any' };
         }
 
+        if (block.type === 'mirror') {
+            if (!block.filters) block.filters = {};
+            
+            if (block.seedId && (!block.filters.seeds_positive || block.filters.seeds_positive.length === 0)) {
+                block.filters.seeds_positive = [{ Id: block.seedId, Name: block.seedName }];
+                delete block.seedId;
+                delete block.seedName;
+            }
+
+            block.filters.seeds_positive = block.filters.seeds_positive ?? [];
+            block.filters.seeds_negative = block.filters.seeds_negative ?? [];
+            block.limit = block.limit ?? 10;
+            block.threshold = block.threshold ?? 0.65;
+        }
+
         if (block.type === 'tv' || (block.type === 'vibe' && block.vibe_type === 'tv')) {
             if (!block.shows) block.shows = [];
             block.shows.forEach(s => {
@@ -212,8 +227,8 @@ export const mixerStore = {
             }
             if (type === 'person') {
                 const [people, studios] = await Promise.all([
-                    post(`api/people?name=${encodeURIComponent(query)}`, null, null, 'GET', true),
-                    post(`api/studios?name=${encodeURIComponent(query)}`, null, null, 'GET', true)
+                    post(`api/people?name=${encodeURIComponent(query)}`, null, null, 'GET', true, false),
+                    post(`api/studios?name=${encodeURIComponent(query)}`, null, null, 'GET', true, false)
                 ]);
                 const results = [];
                 if (Array.isArray(people)) {
@@ -223,6 +238,13 @@ export const mixerStore = {
                     studios.forEach(s => results.push({ type: 'studio', data: s, text: `${s.Name} (Studio)` }));
                 }
                 return results;
+            }
+            if (type === 'media') {
+                 const res = await post(`api/media/search?query=${encodeURIComponent(query)}`, null, null, 'GET', true, false);
+                 if (Array.isArray(res)) {
+                     return res.map(m => ({ type: 'media', data: m, text: `${m.Name} (${m.Year || '?'})` }));
+                 }
+                 return [];
             }
         } catch (e) { return []; }
     },
@@ -275,6 +297,20 @@ export const mixerStore = {
         if (nextKey) {
             block.filters[nextKey].push(clonedItem);
         }
+        this.updatePreviewCount(block);
+    },
+
+    cycleEchoToken(block, key, item) {
+        if (!block || !item) return;
+        const sourceArray = block.filters[key];
+        const index = sourceArray.indexOf(item);
+        if (index === -1) return;
+
+        const clonedItem = JSON.parse(JSON.stringify(item));
+        sourceArray.splice(index, 1);
+
+        const nextKey = (key === 'seeds_positive') ? 'seeds_negative' : 'seeds_positive';
+        block.filters[nextKey].push(clonedItem);
         this.updatePreviewCount(block);
     },
 
@@ -387,6 +423,8 @@ export const mixerStore = {
             block = { type: 'movie', filters: { watched_status: 'all', sort_by: 'Random', parent_ids: this.library.libraryData.map(l => l.Id), year_from: 1920, year_to: new Date().getFullYear(), release_within_days: 0 } };
         } else if (type === 'music') {
             block = { type: 'music', music: { mode: 'album', count: 10, filters: { sort_by: 'Random', limit: 25, genres: [], genre_match: 'any' } } };
+        } else if (type === 'mirror') {
+            block = { type: 'mirror', filters: { seeds_positive: [], seeds_negative: [] }, limit: 10, threshold: 0.65 };
         }
 
         if (block) {

--- a/templates/partials/_builder_pane.html
+++ b/templates/partials/_builder_pane.html
@@ -116,6 +116,7 @@
                     {% include 'partials/_movie_block.html' %}
                     {% include 'partials/_music_block.html' %}
                     {% include 'partials/_vibe_block.html' %}
+                    {% include 'partials/_mirror_block.html' %}
                 </div>
             </template>
         </div>
@@ -135,6 +136,7 @@
                     <div class="dropdown-menu dropdown-up" x-show="open" x-cloak @click.outside="open = false">
                         <a href="#" class="dropdown-item" @click.prevent="open = false; $store.mixer.addBlock('tv')"><span class="dropdown-icon" x-html="$store.icons.tv"></span> TV Block</a>
                         <a href="#" class="dropdown-item" @click.prevent="open = false; $store.mixer.addBlock('movie')"><span class="dropdown-icon" x-html="$store.icons.film"></span> Movie Block</a>
+                        <a href="#" class="dropdown-item" @click.prevent="open = false; $store.mixer.addBlock('mirror')"><span class="dropdown-icon" x-html="$store.icons.shuffle"></span> Echo Block</a>
                         <a href="#" class="dropdown-item" @click.prevent="open = false; $store.mixer.addBlock('music')"><span class="dropdown-icon" x-html="$store.icons.music"></span> Music Block</a>
                     </div>
                 </div>

--- a/templates/partials/_mirror_block.html
+++ b/templates/partials/_mirror_block.html
@@ -1,8 +1,8 @@
 <!-- templates/partials/_mirror_block.html -->
 <template x-if="block && block.type === 'mirror'">
-    <div x-data="{ 
-        editModalOpen: false, 
-        searchQuery: '', 
+    <div x-data="{
+        editModalOpen: false,
+        searchQuery: '',
         suggestions: [],
         async performSearch(blk) {
             if (this.searchQuery.length < 2) {
@@ -14,10 +14,10 @@
                 const res = await fetch('api/media/search?query=' + encodeURIComponent(this.searchQuery) + '&_cb=' + Date.now());
                 const data = await res.json();
                 if (Array.isArray(data)) {
-                    this.suggestions = data.map(m => ({ 
-                        type: 'media', 
-                        data: m, 
-                        text: m.Name + ' (' + (m.Year || '?') + ')' 
+                    this.suggestions = data.map(m => ({
+                        type: 'media',
+                        data: m,
+                        text: m.Name + ' (' + (m.Year || '?') + ')'
                     }));
                 } else {
                     this.suggestions = [];
@@ -46,7 +46,7 @@
                                 <template x-if="block.filters && block.filters.seeds_positive.length > 0">
                                     <div class="curated-preview-text">
                                         <span class="bold color-accent" x-text="block.filters.seeds_positive.map(s => s.Name).join(', ')"></span>
-                                        
+
                                         <template x-if="block.filters.seeds_negative.length > 0">
                                             <span class="text-subtle"> (minus <span x-text="block.filters.seeds_negative.map(s => s.Name).join(', ')"></span>)</span>
                                         </template>
@@ -68,7 +68,7 @@
                                                 </template>
                                             </span>
                                         </template>
-                                        
+
                                         <!-- No Matches Found -->
                                         <template x-if="!block._previewLoading && (!block._previewItems || block._previewItems.length === 0)">
                                             <span class="text-subtle italic"> — No echoes found at this depth</span>
@@ -84,6 +84,9 @@
                                 <span class="badge ai-chip">Echo</span>
                                 <template x-if="block.filters && block.filters.seeds_positive.length > 0">
                                     <span class="badge badge-outline-subtle" x-text="block.limit + ' matches • ' + (block.threshold < 0.6 ? 'Strict' : (block.threshold > 0.75 ? 'Discovery' : 'Balanced'))"></span>
+                                    <template x-if="block.filters.mixed_echo">
+                                        <span class="badge badge-outline-accent">Mixed Format</span>
+                                    </template>
                                 </template>
                             </div>
                         </div>
@@ -111,8 +114,38 @@
                     <button type="button" class="icon-btn" @click="editModalOpen = false">&times;</button>
                 </div>
                 <div class="modal-body">
-                    <p class="text-subtle mb-md">Select one or more items to use as “seeds.” MixerBee will find media that matches their combined feel. Use negative seeds to exclude specific concepts</p>
-                    
+                    <p class="text-subtle mb-md">Search for  one or more items to use as seeds. MixerBee will find media that matches their combined feel. Use negative seeds to exclude specific concepts</p>
+
+                    <!-- Search Input -->
+                    <div class="mb-lg" style="position: relative; width: 100%; display: block;">
+                        <label class="field-label">Search Library</label>
+                        <div style="position: relative; width: 100%;">
+                            <input type="search"
+                                    style="width: 100% !important; margin: 0; display: block; box-sizing: border-box;"
+                                    placeholder="Type a movie or show name..."
+                                    x-model="searchQuery"
+                                    @input.debounce.300ms="performSearch(block)">
+
+                            <div x-show="block._previewLoading" style="position: absolute; right: 12px; top: 50%; transform: translateY(-50%); pointer-events: none;" x-cloak>
+                                <div class="spinner small"></div>
+                            </div>
+                        </div>
+
+                        <div class="autocomplete-suggestions"
+                             style="position: absolute; left: 0; right: 0; top: 100%; z-index: 1100; max-height: 250px; overflow-y: auto; background: #1e1e1e !important; border: 1px solid var(--accent); box-shadow: 0 10px 30px rgba(0,0,0,0.6); border-radius: 0 0 var(--radius-sm) var(--radius-sm);"
+                             x-show="suggestions.length > 0"
+                             x-cloak>
+                            <ul style="margin: 0; padding: 0; list-style: none;">
+                                <template x-for="s in suggestions" :key="block._uid + '_mir_' + s.data.Id">
+                                    <li style="padding: 12px; cursor: pointer; border-bottom: 1px solid rgba(255,255,255,0.05); color: #ffffff;"
+                                        class="dropdown-item-hover"
+                                        @click="if(!block.filters.seeds_positive.some(x => x.Id === s.data.Id)) block.filters.seeds_positive.push({ Id: s.data.Id, Name: s.data.Name }); searchQuery = ''; suggestions = []; $store.mixer.updatePreviewCount(block)"
+                                        x-text="s.text"></li>
+                                </template>
+                            </ul>
+                        </div>
+                    </div>
+
                     <!-- Selection Indicator -->
                     <div class="mb-lg">
                         <label class="field-label">Active Seeds</label>
@@ -141,39 +174,9 @@
                         </div>
                     </div>
 
-                    <!-- Search Input -->
-                    <div class="mb-lg" style="position: relative; width: 100%; display: block;">
-                        <label class="field-label">Search Library</label>
-                        <div style="position: relative; width: 100%;">
-                            <input type="search" 
-                                    style="width: 100% !important; margin: 0; display: block; box-sizing: border-box;"
-                                    placeholder="Type a movie or show name..." 
-                                    x-model="searchQuery" 
-                                    @input.debounce.300ms="performSearch(block)">
-                            
-                            <div x-show="block._previewLoading" style="position: absolute; right: 12px; top: 50%; transform: translateY(-50%); pointer-events: none;" x-cloak>
-                                <div class="spinner small"></div>
-                            </div>
-                        </div>
-                        
-                        <div class="autocomplete-suggestions" 
-                             style="position: absolute; left: 0; right: 0; top: 100%; z-index: 1100; max-height: 250px; overflow-y: auto; background: #1e1e1e !important; border: 1px solid var(--accent); box-shadow: 0 10px 30px rgba(0,0,0,0.6); border-radius: 0 0 var(--radius-sm) var(--radius-sm);"
-                             x-show="suggestions.length > 0" 
-                             x-cloak>
-                            <ul style="margin: 0; padding: 0; list-style: none;">
-                                <template x-for="s in suggestions" :key="block._uid + '_mir_' + s.data.Id">
-                                    <li style="padding: 12px; cursor: pointer; border-bottom: 1px solid rgba(255,255,255,0.05); color: #ffffff;"
-                                        class="dropdown-item-hover"
-                                        @click="if(!block.filters.seeds_positive.some(x => x.Id === s.data.Id)) block.filters.seeds_positive.push({ Id: s.data.Id, Name: s.data.Name }); searchQuery = ''; suggestions = []; $store.mixer.updatePreviewCount(block)" 
-                                        x-text="s.text"></li>
-                                </template>
-                            </ul>
-                        </div>
-                    </div>
-
                     <fieldset class="filter-group">
                         <legend>Similarity Tuning</legend>
-                        
+
                         <div class="tweak-item mb-md">
                             <div class="tweak-label-row">
                                 <span class="tweak-title">Match Limit</span>
@@ -182,7 +185,7 @@
                             <input type="range" min="1" max="50" step="1" style="width: 100%;" x-model.number="block.limit" @change="$store.mixer.updatePreviewCount(block)">
                         </div>
 
-                        <div class="tweak-item">
+                        <div class="tweak-item mb-md">
                             <div class="tweak-label-row">
                                 <span class="tweak-title">Exploration Depth</span>
                                 <span class="tweak-value" x-text="block.threshold.toFixed(2)"></span>
@@ -193,6 +196,17 @@
                                 <span class="pill-btn grow-1 text-center" :class="block.threshold === 0.85 ? 'active' : ''" @click="block.threshold = 0.85; $store.mixer.updatePreviewCount(block)">Discovery</span>
                             </div>
                             <p class="tweak-description mt-xs">"Discovery" allows items that share a deeper thematic bond even if the genres differ.</p>
+                        </div>
+
+                        <div class="tweak-item">
+                            <div class="tweak-label-row">
+                                <span class="tweak-title">Format Matching</span>
+                            </div>
+                            <div class="toggle-pill w-full">
+                                <span class="pill-btn grow-1 text-center" :class="!block.filters.mixed_echo ? 'active' : ''" @click="block.filters.mixed_echo = false; $store.mixer.updatePreviewCount(block)">Same Type</span>
+                                <span class="pill-btn grow-1 text-center" :class="block.filters.mixed_echo ? 'active' : ''" @click="block.filters.mixed_echo = true; $store.mixer.updatePreviewCount(block)">Mixed Echo</span>
+                            </div>
+                            <p class="tweak-description mt-xs">"Mixed Echo" allows results to include both Movies and Series regardless of your seed types.</p>
                         </div>
                     </fieldset>
                 </div>

--- a/templates/partials/_mirror_block.html
+++ b/templates/partials/_mirror_block.html
@@ -1,0 +1,205 @@
+<!-- templates/partials/_mirror_block.html -->
+<template x-if="block && block.type === 'mirror'">
+    <div x-data="{ 
+        editModalOpen: false, 
+        searchQuery: '', 
+        suggestions: [],
+        async performSearch(blk) {
+            if (this.searchQuery.length < 2) {
+                this.suggestions = [];
+                return;
+            }
+            blk._previewLoading = true;
+            try {
+                const res = await fetch('api/media/search?query=' + encodeURIComponent(this.searchQuery) + '&_cb=' + Date.now());
+                const data = await res.json();
+                if (Array.isArray(data)) {
+                    this.suggestions = data.map(m => ({ 
+                        type: 'media', 
+                        data: m, 
+                        text: m.Name + ' (' + (m.Year || '?') + ')' 
+                    }));
+                } else {
+                    this.suggestions = [];
+                }
+            } catch (e) {
+                this.suggestions = [];
+            }
+            blk._previewLoading = false;
+        }
+    }" x-init="$store.mixer.ensureBlockState(block)">
+        <details class="mixed-block mirror-block" :open="index === $store.mixer.blocks.length - 1">
+            {% set default_title = 'Echo Block' %}
+            {% include 'partials/_block_header.html' %}
+
+            <div class="mixed-block-body">
+                <div class="block-summary-card">
+                    <div class="flex-row align-center gap-lg">
+                        <div class="curated-stat-box shrink-0">
+                            <div class="summary-label">Matches</div>
+                            <div class="curated-count" x-text="block._previewLoading ? '...' : (block._previewCount ?? '0')"></div>
+                        </div>
+
+                        <div class="grow-1">
+                            <div class="summary-label">Seed Environment</div>
+                            <div class="summary-content mb-sm">
+                                <template x-if="block.filters && block.filters.seeds_positive.length > 0">
+                                    <div class="curated-preview-text">
+                                        <span class="bold color-accent" x-text="block.filters.seeds_positive.map(s => s.Name).join(', ')"></span>
+                                        
+                                        <template x-if="block.filters.seeds_negative.length > 0">
+                                            <span class="text-subtle"> (minus <span x-text="block.filters.seeds_negative.map(s => s.Name).join(', ')"></span>)</span>
+                                        </template>
+
+                                        <!-- Loading State -->
+                                        <template x-if="block._previewLoading">
+                                            <span class="text-subtle italic"> — Finding echoes...</span>
+                                        </template>
+
+                                        <!-- Preview Matches -->
+                                        <template x-if="!block._previewLoading && block._previewItems && block._previewItems.length > 0">
+                                            <span>
+                                                <span class="text-subtle"> — </span>
+                                                <template x-for="(item, i) in block._previewItems.slice(0, 3)" :key="block._uid + '_mirprev_' + i">
+                                                    <span x-text="(item.name || item.Name || 'Unknown') + (i < Math.min(block._previewItems.length, 3) - 1 ? ', ' : '')"></span>
+                                                </template>
+                                                <template x-if="block._previewCount > 3">
+                                                    <span class="text-subtle"> + <span x-text="block._previewCount - 3"></span> more</span>
+                                                </template>
+                                            </span>
+                                        </template>
+                                        
+                                        <!-- No Matches Found -->
+                                        <template x-if="!block._previewLoading && (!block._previewItems || block._previewItems.length === 0)">
+                                            <span class="text-subtle italic"> — No echoes found at this depth</span>
+                                        </template>
+                                    </div>
+                                </template>
+                                <template x-if="!block.filters || block.filters.seeds_positive.length === 0">
+                                    <div class="text-subtle italic">No seed items selected</div>
+                                </template>
+                            </div>
+
+                            <div class="flex-row flex-wrap gap-sm align-center">
+                                <span class="badge ai-chip">Echo</span>
+                                <template x-if="block.filters && block.filters.seeds_positive.length > 0">
+                                    <span class="badge badge-outline-subtle" x-text="block.limit + ' matches • ' + (block.threshold < 0.6 ? 'Strict' : (block.threshold > 0.75 ? 'Discovery' : 'Balanced'))"></span>
+                                </template>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="mt-md curated-footer flex-row justify-between align-center">
+                        <div class="flex-row gap-xs">
+                             <button type="button" class="secondary small align-center gap-xs" @click="$store.mixer.previewPlaylist($el, [block])" :disabled="!block.filters || block.filters.seeds_positive.length === 0">
+                                <span x-html="$store.icons.list"></span> Full List
+                            </button>
+                        </div>
+                        <button type="button" class="secondary small align-center gap-xs" @click="editModalOpen = true">
+                            <span x-html="$store.icons.search"></span> Configure Echo
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </details>
+
+        <!-- Echo Settings Modal -->
+        <div class="modal-overlay" x-show="editModalOpen" x-cloak style="z-index: 9999;">
+            <div class="modal-window" @click.outside="editModalOpen = false" style="max-width: 550px;">
+                <div class="modal-header">
+                    <h2>Echo Settings</h2>
+                    <button type="button" class="icon-btn" @click="editModalOpen = false">&times;</button>
+                </div>
+                <div class="modal-body">
+                    <p class="text-subtle mb-md">Select one or more items to use as “seeds.” MixerBee will find media that matches their combined feel. Use negative seeds to exclude specific concepts</p>
+                    
+                    <!-- Selection Indicator -->
+                    <div class="mb-lg">
+                        <label class="field-label">Active Seeds</label>
+                        <div class="token-container" style="min-height: 42px; padding: 6px; background: rgba(0,0,0,0.2); border-radius: var(--radius-sm); border: 1px solid rgba(255,255,255,0.05);">
+                            <template x-for="s in (block.filters?.seeds_positive || [])" :key="block._uid + '_pos_' + s.Id">
+                                <span class="token token-logic-any" @click="$store.mixer.cycleEchoToken(block, 'seeds_positive', s)">
+                                    <span class="token-state-trigger">⊕</span>
+                                    <span class="token-label" x-text="s.Name"></span>
+                                    <b class="token-remove" @click.stop="$store.mixer.removeToken(block, 'seeds_positive', block.filters.seeds_positive.indexOf(s))">&times;</b>
+                                </span>
+                            </template>
+                            <template x-for="s in (block.filters?.seeds_negative || [])" :key="block._uid + '_neg_' + s.Id">
+                                <span class="token token-logic-exclude" @click="$store.mixer.cycleEchoToken(block, 'seeds_negative', s)">
+                                    <span class="token-state-trigger">⊖</span>
+                                    <span class="token-label" x-text="s.Name"></span>
+                                    <b class="token-remove" @click.stop="$store.mixer.removeToken(block, 'seeds_negative', block.filters.seeds_negative.indexOf(s))">&times;</b>
+                                </span>
+                            </template>
+                            <template x-if="(!block.filters || (block.filters.seeds_positive.length === 0 && block.filters.seeds_negative.length === 0))">
+                                <span class="text-subtle italic px-sm" style="font-size: 0.85rem; line-height: 30px;">No seeds selected. Search below...</span>
+                            </template>
+                        </div>
+                        <div class="flex-row gap-md filter-logic-help mt-xs" style="font-size: 0.75rem;">
+                            <span class="flex-row align-center gap-xs" style="color: var(--accent);">⊕ Like This</span>
+                            <span class="flex-row align-center gap-xs" style="color: var(--danger);">⊖ Not Like This</span>
+                        </div>
+                    </div>
+
+                    <!-- Search Input -->
+                    <div class="mb-lg" style="position: relative; width: 100%; display: block;">
+                        <label class="field-label">Search Library</label>
+                        <div style="position: relative; width: 100%;">
+                            <input type="search" 
+                                    style="width: 100% !important; margin: 0; display: block; box-sizing: border-box;"
+                                    placeholder="Type a movie or show name..." 
+                                    x-model="searchQuery" 
+                                    @input.debounce.300ms="performSearch(block)">
+                            
+                            <div x-show="block._previewLoading" style="position: absolute; right: 12px; top: 50%; transform: translateY(-50%); pointer-events: none;" x-cloak>
+                                <div class="spinner small"></div>
+                            </div>
+                        </div>
+                        
+                        <div class="autocomplete-suggestions" 
+                             style="position: absolute; left: 0; right: 0; top: 100%; z-index: 1100; max-height: 250px; overflow-y: auto; background: #1e1e1e !important; border: 1px solid var(--accent); box-shadow: 0 10px 30px rgba(0,0,0,0.6); border-radius: 0 0 var(--radius-sm) var(--radius-sm);"
+                             x-show="suggestions.length > 0" 
+                             x-cloak>
+                            <ul style="margin: 0; padding: 0; list-style: none;">
+                                <template x-for="s in suggestions" :key="block._uid + '_mir_' + s.data.Id">
+                                    <li style="padding: 12px; cursor: pointer; border-bottom: 1px solid rgba(255,255,255,0.05); color: #ffffff;"
+                                        class="dropdown-item-hover"
+                                        @click="if(!block.filters.seeds_positive.some(x => x.Id === s.data.Id)) block.filters.seeds_positive.push({ Id: s.data.Id, Name: s.data.Name }); searchQuery = ''; suggestions = []; $store.mixer.updatePreviewCount(block)" 
+                                        x-text="s.text"></li>
+                                </template>
+                            </ul>
+                        </div>
+                    </div>
+
+                    <fieldset class="filter-group">
+                        <legend>Similarity Tuning</legend>
+                        
+                        <div class="tweak-item mb-md">
+                            <div class="tweak-label-row">
+                                <span class="tweak-title">Match Limit</span>
+                                <span class="tweak-value" x-text="block.limit"></span>
+                            </div>
+                            <input type="range" min="1" max="50" step="1" style="width: 100%;" x-model.number="block.limit" @change="$store.mixer.updatePreviewCount(block)">
+                        </div>
+
+                        <div class="tweak-item">
+                            <div class="tweak-label-row">
+                                <span class="tweak-title">Exploration Depth</span>
+                                <span class="tweak-value" x-text="block.threshold.toFixed(2)"></span>
+                            </div>
+                            <div class="toggle-pill w-full">
+                                <span class="pill-btn grow-1 text-center" :class="block.threshold === 0.50 ? 'active' : ''" @click="block.threshold = 0.50; $store.mixer.updatePreviewCount(block)">Strict</span>
+                                <span class="pill-btn grow-1 text-center" :class="block.threshold === 0.65 ? 'active' : ''" @click="block.threshold = 0.65; $store.mixer.updatePreviewCount(block)">Balanced</span>
+                                <span class="pill-btn grow-1 text-center" :class="block.threshold === 0.85 ? 'active' : ''" @click="block.threshold = 0.85; $store.mixer.updatePreviewCount(block)">Discovery</span>
+                            </div>
+                            <p class="tweak-description mt-xs">"Discovery" allows items that share a deeper thematic bond even if the genres differ.</p>
+                        </div>
+                    </fieldset>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="primary" @click="editModalOpen = false">Done</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</template>


### PR DESCRIPTION
- Added `search_by_composite_similarity` for similarity engine.
- Used vector arithmetic to support multi-seed blending (averaging multiple positive seeds) and negative concept exclusion.
- Added `_process_mirror_block` in `builder.py` This "over" fetches nearest vector neighbors and samples them to make results non-deterministic on repeat builds.
- Added `/api/media/search` endpoint for global media lookups directly against the vector DB.
- Created `_mirror_block.html` template with configuration modal for similarity tuning.
- Updated `mixerStore.js` to handle the new `seeds_positive` and `seeds_negative` data structures.
- Added `cycleEchoToken()` logic to interactively toggle seed media between "Like This" (⊕) and "Not Like This" (⊖).